### PR TITLE
Adjusting task retries and timeouts in order to reduce transient horizon errors

### DIFF
--- a/app/Jobs/AvatarPipeline/RemoteAvatarFetch.php
+++ b/app/Jobs/AvatarPipeline/RemoteAvatarFetch.php
@@ -30,7 +30,7 @@ class RemoteAvatarFetch implements ShouldQueue
      *
      * @var int
      */
-    public $tries = 1;
+    public $tries = 3; # Retry this action, it can often fail due to network issues
 
     public $timeout = 300;
 

--- a/app/Jobs/LikePipeline/LikePipeline.php
+++ b/app/Jobs/LikePipeline/LikePipeline.php
@@ -32,7 +32,7 @@ class LikePipeline implements ShouldQueue
      */
     public $deleteWhenMissingModels = true;
 
-    public $timeout = 5;
+    public $timeout = 10;
 
     public $tries = 1;
 

--- a/app/Jobs/LikePipeline/UnlikePipeline.php
+++ b/app/Jobs/LikePipeline/UnlikePipeline.php
@@ -29,7 +29,8 @@ class UnlikePipeline implements ShouldQueue
 	 */
 	public $deleteWhenMissingModels = true;
 
-	public $timeout = 5;
+	public $timeout = 10;
+	
 	public $tries = 1;
 
 	/**

--- a/app/Jobs/SharePipeline/SharePipeline.php
+++ b/app/Jobs/SharePipeline/SharePipeline.php
@@ -21,6 +21,8 @@ use League\Fractal\Serializer\ArraySerializer;
 
 class SharePipeline implements ShouldQueue
 {
+    public $tries = 2; # For some reason this particular activity has a habit of popping failed, with a constraint violation error, but works when retried ... so we'll retry it once
+
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     protected $status;


### PR DESCRIPTION
Changes to the timeout and retry on the following tasks in order to attempt to make Horizon not constantly raise Failures that are transient:

- RemoteAvatarFetch
- Share
- Like
- Unlike