### PR TITLE
Correct user stats to ignore deleted

### DIFF
--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -1683,7 +1683,7 @@ class ApiV1Controller extends Controller
 
             $stats = Cache::remember('api:v1:instance-data:stats:v0', 43200, function () {
                 return [
-                    'user_count' => (int) User::count(),
+                    'user_count' => (int) User::whereNull('status')->count(), # Only get null status - these are the "active" users,
                     'status_count' => (int) StatusService::totalLocalStatuses(),
                     'domain_count' => (int) Instance::count(),
                 ];

--- a/app/Http/Controllers/Api/InstanceApiController.php
+++ b/app/Http/Controllers/Api/InstanceApiController.php
@@ -40,7 +40,7 @@ class InstanceApiController extends Controller {
 			'version' => config('pixelfed.version'),
 			'urls' => [],
 			'stats' => [
-				'user_count' => User::count(),
+				'user_count' => User::whereNull('status')->count(), # Only get null status - these are the "active" users
 				'status_count' => StatusService::totalLocalStatuses(),
 				'domain_count' => Instance::count()
 			],

--- a/app/Http/Controllers/PixelfedDirectoryController.php
+++ b/app/Http/Controllers/PixelfedDirectoryController.php
@@ -143,7 +143,7 @@ class PixelfedDirectoryController extends Controller
 
         $statusesCount = InstanceService::totalLocalStatuses();
         $usersCount = Cache::remember('api:nodeinfo:users', 43200, function () {
-            return User::count();
+            return UUser::whereNull('status')->count(); # Only get null status - these are the "active" users
         });
         $res['stats'] = [
             'user_count' => (int) $usersCount,

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -59,7 +59,7 @@ class SiteController extends Controller
     public function about()
     {
         return Cache::remember('site.about_v2', now()->addMinutes(15), function () {
-            $user_count = number_format(User::count());
+            $user_count = number_format(User::whereNull('status')->count()); # Only get null status - these are the "active" users);
             $post_count = number_format(StatusService::totalLocalStatuses());
             $rules = config_cache('app.rules') ? json_decode(config_cache('app.rules'), true) : null;
 

--- a/app/Services/AdminStatsService.php
+++ b/app/Services/AdminStatsService.php
@@ -99,7 +99,7 @@ class AdminStatsService
                 'statuses' => PrettyNumber::convert(intval(StatusService::totalLocalStatuses())),
                 'statuses_monthly' => PrettyNumber::convert(Status::where('created_at', '>', now()->subMonth())->count()),
                 'profiles' => PrettyNumber::convert(Profile::count()),
-                'users' => PrettyNumber::convert(User::count()),
+                'users' => PrettyNumber::convert(User::whereNull('status')->count()),
                 'users_monthly' => PrettyNumber::convert(User::where('created_at', '>', now()->subMonth())->count()),
                 'instances' => PrettyNumber::convert(Instance::count()),
                 'media' => PrettyNumber::convert(Media::count()),
@@ -116,7 +116,7 @@ class AdminStatsService
             return [
                 'statuses' => PrettyNumber::convert(intval(StatusService::totalLocalStatuses())),
                 'profiles' => PrettyNumber::convert(Profile::count()),
-                'users' => PrettyNumber::convert(User::count()),
+                'users' => PrettyNumber::convert(User::whereNull('status')->count()),
                 'instances' => PrettyNumber::convert(Instance::count()),
             ];
         });

--- a/app/Services/LandingService.php
+++ b/app/Services/LandingService.php
@@ -14,7 +14,7 @@ class LandingService
         $activeMonth = Nodeinfo::activeUsersMonthly();
 
         $totalUsers = Cache::remember('api:nodeinfo:users', 43200, function () {
-            return User::count();
+            return User::whereNull('status')->count(); # Only get null status - these are the "active" users
         });
 
         $postCount = InstanceService::totalLocalStatuses();

--- a/app/Util/Site/Nodeinfo.php
+++ b/app/Util/Site/Nodeinfo.php
@@ -15,7 +15,7 @@ class Nodeinfo
             $activeMonth = self::activeUsersMonthly();
 
             $users = Cache::remember('api:nodeinfo:users', 43200, function () {
-                return User::count();
+                return User::whereNull('status')->count(); # Only get null status - these are the "active" users
             });
 
             $statuses = InstanceService::totalLocalStatuses();


### PR DESCRIPTION
This has annoyed me for a while, that the user counts showed deleted accounts etc.

This PR removes them and only shows ACTUAL users.