### PR TITLE
Correct local post count

### DIFF
--- a/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
+++ b/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
@@ -53,12 +53,14 @@ class InstanceUpdateTotalLocalPosts extends Command
 
     protected function initCache()
     {
-        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
+        $count = DB::table('statuses')->whereNull(['url', 'deleted_at'])->count();
         $res = [
             'count' => $count,
         ];
         Storage::put('total_local_posts.json', json_encode($res, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         ConfigCacheService::put('instance.stats.total_local_posts', $res['count']);
+        $realCount = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
+        ConfigCacheService::put('instance.stats.real_total_local_posts', $realCount);
     }
 
     protected function getCached()
@@ -68,12 +70,13 @@ class InstanceUpdateTotalLocalPosts extends Command
 
     protected function updateAndCache()
     {
-        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
+        $count = DB::table('statuses')->whereNull(['url', 'deleted_at'])->count();
         $res = [
             'count' => $count,
         ];
         Storage::put('total_local_posts.json', json_encode($res, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         ConfigCacheService::put('instance.stats.total_local_posts', $res['count']);
-
+        $realCount = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
+        ConfigCacheService::put('instance.stats.real_total_local_posts', $realCount);
     }
 }

--- a/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
+++ b/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
@@ -53,7 +53,7 @@ class InstanceUpdateTotalLocalPosts extends Command
 
     protected function initCache()
     {
-        $count = DB::table('statuses')->whereNull(['url', 'deleted_at'])->count();
+        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to', 'reblog_of_id', 'deleted_at'])->count();
         $res = [
             'count' => $count,
         ];
@@ -68,7 +68,7 @@ class InstanceUpdateTotalLocalPosts extends Command
 
     protected function updateAndCache()
     {
-        $count = DB::table('statuses')->whereNull(['url', 'deleted_at'])->count();
+        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to', 'reblog_of_id', 'deleted_at'])->count();
         $res = [
             'count' => $count,
         ];

--- a/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
+++ b/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
@@ -53,7 +53,7 @@ class InstanceUpdateTotalLocalPosts extends Command
 
     protected function initCache()
     {
-        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to', 'reblog_of_id', 'deleted_at'])->count();
+        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
         $res = [
             'count' => $count,
         ];
@@ -68,7 +68,7 @@ class InstanceUpdateTotalLocalPosts extends Command
 
     protected function updateAndCache()
     {
-        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to', 'reblog_of_id', 'deleted_at'])->count();
+        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
         $res = [
             'count' => $count,
         ];

--- a/app/Http/Controllers/Api/AdminApiController.php
+++ b/app/Http/Controllers/Api/AdminApiController.php
@@ -850,7 +850,8 @@ class AdminApiController extends Controller
             $res['users']['min'] = collect($res['users']['days'])->min('count');
             $res['users']['max'] = collect($res['users']['days'])->max('count');
             $res['users']['change'] = collect($res['users']['days'])->sum('count');
-            $res['posts']['total'] = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
+            $res['posts']['total'] = DB::table('statuses')->whereNull(['uri', 'deleted_at'])->count();
+            $res['posts']['real_total'] = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
             $res['posts']['min'] = collect($res['posts']['days'])->min('count');
             $res['posts']['max'] = collect($res['posts']['days'])->max('count');
             $res['posts']['change'] = collect($res['posts']['days'])->sum('count');

--- a/app/Http/Controllers/Api/AdminApiController.php
+++ b/app/Http/Controllers/Api/AdminApiController.php
@@ -850,7 +850,7 @@ class AdminApiController extends Controller
             $res['users']['min'] = collect($res['users']['days'])->min('count');
             $res['users']['max'] = collect($res['users']['days'])->max('count');
             $res['users']['change'] = collect($res['users']['days'])->sum('count');
-            $res['posts']['total'] = DB::table('statuses')->whereNull(['url', 'in_reply_to', 'reblog_of_id', 'deleted_at'])->count();
+            $res['posts']['total'] = DB::table('statuses')->whereNull(['url', 'in_reply_to_id', 'reblog_of_id', 'deleted_at'])->count();
             $res['posts']['min'] = collect($res['posts']['days'])->min('count');
             $res['posts']['max'] = collect($res['posts']['days'])->max('count');
             $res['posts']['change'] = collect($res['posts']['days'])->sum('count');

--- a/app/Http/Controllers/Api/AdminApiController.php
+++ b/app/Http/Controllers/Api/AdminApiController.php
@@ -850,7 +850,7 @@ class AdminApiController extends Controller
             $res['users']['min'] = collect($res['users']['days'])->min('count');
             $res['users']['max'] = collect($res['users']['days'])->max('count');
             $res['users']['change'] = collect($res['users']['days'])->sum('count');
-            $res['posts']['total'] = DB::table('statuses')->whereNull('uri')->count();
+            $res['posts']['total'] = DB::table('statuses')->whereNull(['url', 'in_reply_to', 'reblog_of_id', 'deleted_at'])->count();
             $res['posts']['min'] = collect($res['posts']['days'])->min('count');
             $res['posts']['max'] = collect($res['posts']['days'])->max('count');
             $res['posts']['change'] = collect($res['posts']['days'])->sum('count');

--- a/app/Http/Controllers/Api/InstanceApiController.php
+++ b/app/Http/Controllers/Api/InstanceApiController.php
@@ -33,6 +33,12 @@ class InstanceApiController extends Controller {
 			];
 		});
 
+        if (env('GLITCH_LANDING_REALSTATCOUNT', false)) {
+            $postCount = StatusService::totalRealLocalStatuses();
+        } else {
+            $postCount = StatusService::totalLocalStatuses();
+        }
+
 		$res = [
 			'uri' => config('pixelfed.domain.app'),
 			'title' => config_cache('app.name'),
@@ -41,7 +47,7 @@ class InstanceApiController extends Controller {
 			'urls' => [],
 			'stats' => [
 				'user_count' => User::whereNull('status')->count(), # Only get null status - these are the "active" users
-				'status_count' => StatusService::totalLocalStatuses(),
+				'status_count' => $postCount,
 				'domain_count' => Instance::count()
 			],
 			'thumbnail' => '',

--- a/app/Services/AdminStatsService.php
+++ b/app/Services/AdminStatsService.php
@@ -99,6 +99,7 @@ class AdminStatsService
                 'statuses' => PrettyNumber::convert(intval(StatusService::totalLocalStatuses())),
                 'real_statuses' => PrettyNumber::convert(intval(StatusService::totalRealLocalStatuses())),
                 'statuses_monthly' => PrettyNumber::convert(Status::where('created_at', '>', now()->subMonth())->count()),
+                'real_statuses_monthly' => PrettyNumber::convert(Status::where('url', '=', 'null')->where('created_at', '>', now()->subMonth())->where('reblog_of_id', '=', 'null')->where('in_reply_to_id', '=', 'null')->count()),
                 'profiles' => PrettyNumber::convert(Profile::count()),
                 'users' => PrettyNumber::convert(User::whereNull('status')->count()),
                 'users_monthly' => PrettyNumber::convert(User::where('created_at', '>', now()->subMonth())->count()),

--- a/app/Services/AdminStatsService.php
+++ b/app/Services/AdminStatsService.php
@@ -97,6 +97,7 @@ class AdminStatsService
             return [
                 'failedjobs' => PrettyNumber::convert(FailedJob::where('failed_at', '>=', \Carbon\Carbon::now()->subDay())->count()),
                 'statuses' => PrettyNumber::convert(intval(StatusService::totalLocalStatuses())),
+                'real_statuses' => PrettyNumber::convert(intval(StatusService::totalRealLocalStatuses())),
                 'statuses_monthly' => PrettyNumber::convert(Status::where('created_at', '>', now()->subMonth())->count()),
                 'profiles' => PrettyNumber::convert(Profile::count()),
                 'users' => PrettyNumber::convert(User::whereNull('status')->count()),
@@ -115,6 +116,7 @@ class AdminStatsService
         return Cache::remember('admin:dashboard:home:data-summary:v0:24hr', $ttl, function () {
             return [
                 'statuses' => PrettyNumber::convert(intval(StatusService::totalLocalStatuses())),
+                'real_statuses' => PrettyNumber::convert(intval(StatusService::totalRealLocalStatuses())),
                 'profiles' => PrettyNumber::convert(Profile::count()),
                 'users' => PrettyNumber::convert(User::whereNull('status')->count()),
                 'instances' => PrettyNumber::convert(Instance::count()),

--- a/app/Services/ConfigCacheService.php
+++ b/app/Services/ConfigCacheService.php
@@ -137,6 +137,7 @@ class ConfigCacheService
                     'filesystems.disks.spaces.use_path_style_endpoint',
 
                     'instance.stats.total_local_posts',
+                    'instance.stats.real_total_local_posts',
                     // 'system.user_mode'
                 ];
 

--- a/app/Services/InstanceService.php
+++ b/app/Services/InstanceService.php
@@ -103,6 +103,11 @@ class InstanceService
         return config_cache('instance.stats.total_local_posts');
     }
 
+    public static function totalRealLocalStatuses()
+    {
+        return config_cache('instance.stats.real_total_local_posts');
+    }    
+
     public static function headerBlurhash()
     {
         return Cache::rememberForever(self::CACHE_KEY_BANNER_BLURHASH, function () {

--- a/app/Services/LandingService.php
+++ b/app/Services/LandingService.php
@@ -17,7 +17,11 @@ class LandingService
             return User::whereNull('status')->count(); # Only get null status - these are the "active" users
         });
 
-        $postCount = InstanceService::totalLocalStatuses();
+        if (env('GLITCH_LANDING_REALSTATCOUNT', false)) {
+            $postCount = InstanceService::totalRealLocalStatuses();
+        } else {
+            $postCount = InstanceService::totalLocalStatuses();
+        }
 
         $contactAccount = Cache::remember('api:v1:instance-data:contact', 604800, function () {
             if (config_cache('instance.admin.pid')) {

--- a/app/Services/StatusService.php
+++ b/app/Services/StatusService.php
@@ -198,4 +198,9 @@ class StatusService
     {
         return InstanceService::totalLocalStatuses();
     }
+
+    public static function totalRealLocalStatuses()
+    {
+        return InstanceService::totalRealLocalStatuses();
+    }    
 }

--- a/app/Util/Site/Nodeinfo.php
+++ b/app/Util/Site/Nodeinfo.php
@@ -18,8 +18,12 @@ class Nodeinfo
                 return User::whereNull('status')->count(); # Only get null status - these are the "active" users
             });
 
-            $statuses = InstanceService::totalLocalStatuses();
-
+            if (env('GLITCH_LANDING_REALSTATCOUNT', false)) {
+                $postCount = InstanceService::totalRealLocalStatuses();
+            } else {
+                $postCount = InstanceService::totalLocalStatuses();
+            }
+    
             $features = ['features' => \App\Util\Site\Config::get()['features']];
 
             return [
@@ -43,7 +47,7 @@ class Nodeinfo
                     'version' => config('pixelfed.version'),
                 ],
                 'usage' => [
-                    'localPosts' => (int) $statuses,
+                    'localPosts' => (int) $postCount,
                     'localComments' => 0,
                     'users' => [
                         'total' => (int) $users,

--- a/database/migrations/2024_06_19_084835_add_total_local_posts_to_config_cache.php
+++ b/database/migrations/2024_06_19_084835_add_total_local_posts_to_config_cache.php
@@ -15,7 +15,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $count = DB::table('statuses')->whereNull(['url', 'deleted_at'])->count();
+        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to', 'reblog_of_id', 'deleted_at'])->count();
         $res = [
             'count' => $count
         ];

--- a/database/migrations/2024_06_19_084835_add_total_local_posts_to_config_cache.php
+++ b/database/migrations/2024_06_19_084835_add_total_local_posts_to_config_cache.php
@@ -15,7 +15,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $count = DB::table('statuses')->whereNull(['url', 'in_reply_to', 'reblog_of_id', 'deleted_at'])->count();
+        $count = DB::table('statuses')->whereNull(['url', 'deleted_at'])->count();
         $res = [
             'count' => $count
         ];

--- a/resources/views/admin/home.blade.php
+++ b/resources/views/admin/home.blade.php
@@ -11,7 +11,7 @@
 				</div>
 			</div>
 			<div v-if="loaded.stats" class="row">
-				<div class="col-xl-3 col-md-6">
+				<div class="col-xl-2 col-md-2">
 					<div class="card card-stats">
 						<div class="card-body">
 							<div class="row">
@@ -28,7 +28,24 @@
 						</div>
 					</div>
 				</div>
-				<div class="col-xl-3 col-md-6">
+				<div class="col-xl-2 col-md-2">
+					<div class="card card-stats">
+						<div class="card-body">
+							<div class="row">
+								<div class="col">
+									<h5 class="card-title text-uppercase text-muted mb-0">Local posts</h5>
+									<span class="h2 font-weight-bold mb-0" v-text="stats.real_statuses"></span>
+								</div>
+								<div class="col-auto">
+									<div class="icon icon-shape bg-gradient-primary text-white rounded-circle shadow">
+										<i class="ni ni-image"></i>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>				
+				<div class="col-xl-2 col-md-2">
 					<div class="card card-stats">
 						<div class="card-body">
 							<div class="row">
@@ -45,7 +62,7 @@
 						</div>
 					</div>
 				</div>
-				<div class="col-xl-3 col-md-6">
+				<div class="col-xl-2 col-md-2">
 					<div class="card card-stats">
 						<div class="card-body">
 							<div class="row">
@@ -62,7 +79,7 @@
 						</div>
 					</div>
 				</div>
-				<div class="col-xl-3 col-md-6">
+				<div class="col-xl-2 col-md-2">
 					<div class="card card-stats">
 						<div class="card-body">
 							<div class="row">

--- a/resources/views/admin/stats.blade.php
+++ b/resources/views/admin/stats.blade.php
@@ -18,7 +18,7 @@
                                 <div class="col">
                                     <h5 class="card-title text-uppercase text-muted mb-0">Total posts</h5>
                                     <span class="h2 font-weight-bold mb-0">{{$data['statuses']}}</span>
-                                </div>
+                                </div>                     
                                 <div class="col-auto">
                                     <div class="icon icon-shape bg-gradient-primary text-white rounded-circle shadow">
                                         <i class="ni ni-image"></i>
@@ -32,6 +32,27 @@
                         </div>
                     </div>
                 </div>
+                <div class="col-xl-3 col-md-6">
+                    <div class="card card-stats">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col">
+                                    <h5 class="card-title text-uppercase text-muted mb-0">Total local posts</h5>
+                                    <span class="h2 font-weight-bold mb-0">{{$data['real_statuses']}}</span>
+                                </div>                     
+                                <div class="col-auto">
+                                    <div class="icon icon-shape bg-gradient-primary text-white rounded-circle shadow">
+                                        <i class="ni ni-image"></i>
+                                    </div>
+                                </div>
+                            </div>
+                            <p class="mt-3 mb-0 text-sm">
+                                <span class="text-success mr-2"><i class="fa fa-arrow-up"></i> {{$data['statuses_monthly']}}</span>
+                                <span class="text-nowrap">in last 30 days</span>
+                            </p>
+                        </div>
+                    </div>
+                </div>                
                 <div class="col-xl-3 col-md-6">
                     <div class="card card-stats">
                         <div class="card-body">

--- a/resources/views/admin/stats.blade.php
+++ b/resources/views/admin/stats.blade.php
@@ -11,7 +11,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-xl-3 col-md-6">
+                <div class="col-xl-2 col-md-2">
                     <div class="card card-stats">
                         <div class="card-body">
                             <div class="row">
@@ -32,12 +32,12 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-xl-3 col-md-6">
+                <div class="col-xl-2 col-md-2">
                     <div class="card card-stats">
                         <div class="card-body">
                             <div class="row">
                                 <div class="col">
-                                    <h5 class="card-title text-uppercase text-muted mb-0">Total local posts</h5>
+                                    <h5 class="card-title text-uppercase text-muted mb-0">Local posts</h5>
                                     <span class="h2 font-weight-bold mb-0">{{$data['real_statuses']}}</span>
                                 </div>                     
                                 <div class="col-auto">
@@ -47,13 +47,13 @@
                                 </div>
                             </div>
                             <p class="mt-3 mb-0 text-sm">
-                                <span class="text-success mr-2"><i class="fa fa-arrow-up"></i> {{$data['statuses_monthly']}}</span>
+                                <span class="text-success mr-2"><i class="fa fa-arrow-up"></i> {{$data['real_statuses_monthly']}}</span>
                                 <span class="text-nowrap">in last 30 days</span>
                             </p>
                         </div>
                     </div>
                 </div>                
-                <div class="col-xl-3 col-md-6">
+                <div class="col-xl-2 col-md-2">
                     <div class="card card-stats">
                         <div class="card-body">
                             <div class="row">
@@ -74,7 +74,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-xl-3 col-md-6">
+                <div class="col-xl-2 col-md-2">
                     <div class="card card-stats">
                         <div class="card-body">
                             <div class="row">
@@ -95,7 +95,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-xl-3 col-md-6">
+                <div class="col-xl-2 col-md-2">
                     <div class="card card-stats">
                         <div class="card-body">
                             <div class="row">


### PR DESCRIPTION
This removes posts which are reblogs or simple comment replies from countings as posts, which artifically inflate the statistics making instances look "bigger". 

E.g. on my instance this brings post count down from 

![image](https://github.com/user-attachments/assets/de8fb8ee-89fc-44d9-a513-b5262037895b)

There was also an error in Admin controller where it was calculating the post count differently :/ 