### PR TITLE
Fix glitch cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 #/.gitignore
 /.idea
 /.vagrant
+/.vscode
 /bootstrap/cache
 /docker-compose-state/
 /Homestead.json
@@ -28,5 +29,7 @@
 /public/build
 
 # Exceptions - these *MUST* be last
+!/.vscode/settings.json
+!/.vscode/extensions.json
 !/bootstrap/cache/.gitignore
 !/public/vendor/horizon/.gitignore

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
     "files.associations": {
         ".env": "shellscript",
         ".env.*": "shellscript"
-    }
+    },
+    "intelephense.environment.phpVersion": "8.4"
 }

--- a/app/Http/Controllers/Api/InstanceApiController.php
+++ b/app/Http/Controllers/Api/InstanceApiController.php
@@ -33,7 +33,7 @@ class InstanceApiController extends Controller {
 			];
 		});
 
-        if (env('GLITCH_LANDING_REALSTATCOUNT', false)) {
+        if ((bool) config('glitch.real_stat_count') == true) {
             $postCount = StatusService::totalRealLocalStatuses();
         } else {
             $postCount = StatusService::totalLocalStatuses();

--- a/app/Http/Controllers/Api/InstanceApiController.php
+++ b/app/Http/Controllers/Api/InstanceApiController.php
@@ -33,7 +33,7 @@ class InstanceApiController extends Controller {
 			];
 		});
 
-        if ((bool) config('glitch.real_stat_count') == true) {
+        if ((bool) config('instance.glitch.real_stat_count') == true) {
             $postCount = StatusService::totalRealLocalStatuses();
         } else {
             $postCount = StatusService::totalLocalStatuses();

--- a/app/Services/Account/RemoteAuthService.php
+++ b/app/Services/Account/RemoteAuthService.php
@@ -166,6 +166,10 @@ class RemoteAuthService
 
     public static function submitToBeagle($ow, $ou, $dw, $du)
     {
+        if ((bool) config('instance.discover.beagle_api') == false) {
+            return;
+        }
+
         try {
             $url = 'https://beagle.pixelfed.net/api/v1/raa/submit';
             $res = Http::throw()->timeout(10)->get($url, [

--- a/app/Services/LandingService.php
+++ b/app/Services/LandingService.php
@@ -17,7 +17,7 @@ class LandingService
             return User::whereNull('status')->count(); # Only get null status - these are the "active" users
         });
 
-        if ((bool) config('glitch.real_stat_count') == true) {
+        if ((bool) config('instance.glitch.real_stat_count') == true) {
             $postCount = InstanceService::totalRealLocalStatuses();
         } else {
             $postCount = InstanceService::totalLocalStatuses();

--- a/app/Services/LandingService.php
+++ b/app/Services/LandingService.php
@@ -17,7 +17,7 @@ class LandingService
             return User::whereNull('status')->count(); # Only get null status - these are the "active" users
         });
 
-        if (env('GLITCH_LANDING_REALSTATCOUNT', false)) {
+        if ((bool) config('glitch.real_stat_count') == true) {
             $postCount = InstanceService::totalRealLocalStatuses();
         } else {
             $postCount = InstanceService::totalLocalStatuses();

--- a/app/Util/Site/Nodeinfo.php
+++ b/app/Util/Site/Nodeinfo.php
@@ -18,7 +18,7 @@ class Nodeinfo
                 return User::whereNull('status')->count(); # Only get null status - these are the "active" users
             });
 
-            if ((bool) config('glitch.real_stat_count') == true) {
+            if ((bool) config('instance.glitch.real_stat_count') == true) {
                 $postCount = InstanceService::totalRealLocalStatuses();
             } else {
                 $postCount = InstanceService::totalLocalStatuses();

--- a/app/Util/Site/Nodeinfo.php
+++ b/app/Util/Site/Nodeinfo.php
@@ -18,7 +18,7 @@ class Nodeinfo
                 return User::whereNull('status')->count(); # Only get null status - these are the "active" users
             });
 
-            if (env('GLITCH_LANDING_REALSTATCOUNT', false)) {
+            if ((bool) config('glitch.real_stat_count') == true) {
                 $postCount = InstanceService::totalRealLocalStatuses();
             } else {
                 $postCount = InstanceService::totalLocalStatuses();

--- a/config/instance.php
+++ b/config/instance.php
@@ -1,6 +1,10 @@
 <?php
 
 return [
+    'glitch' => [
+        'real_stat_count' => env('GLITCH_LANDING_REALSTATCOUNT', false),
+    ],
+
     'force_https_urls' => env('FORCE_HTTPS_URLS', true),
 
     'description' => env('INSTANCE_DESCRIPTION', 'Pixelfed Glitch - Photo sharing for everyone'),

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1737746512,
+        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
         "type": "github"
       },
       "original": {

--- a/resources/views/admin/diagnostics/home.blade.php
+++ b/resources/views/admin/diagnostics/home.blade.php
@@ -863,7 +863,7 @@
 	<tr>
 		<td><span class="badge badge-primary">GLITCH</span></td>
 		<td><strong>GLITCH_LANDING_REALSTATCOUNT</strong></td>
-		<td><span>"{{(bool) config_cache('instance.glitch.real_stat_count') ? '✅ true' : '❌ false' }}"</span></td>
+		<td><span>{{(bool) config_cache('instance.glitch.real_stat_count') ? '✅ true' : '❌ false' }}</span></td>
 	</tr>	
       </tbody>
       </table>

--- a/resources/views/admin/diagnostics/home.blade.php
+++ b/resources/views/admin/diagnostics/home.blade.php
@@ -863,7 +863,7 @@
 	<tr>
 		<td><span class="badge badge-primary">GLITCH</span></td>
 		<td><strong>GLITCH_LANDING_REALSTATCOUNT</strong></td>
-		<td><span>"{{config_cache('instance.glitch.real_stat_count')}}"</span></td>
+		<td><span>"{{(bool) config_cache('instance.glitch.real_stat_count') ? '✅ true' : '❌ false' }}"</span></td>
 	</tr>	
       </tbody>
       </table>

--- a/resources/views/admin/diagnostics/home.blade.php
+++ b/resources/views/admin/diagnostics/home.blade.php
@@ -855,12 +855,16 @@
 		<td><strong>SESSION_DOMAIN</strong></td>
 		<td><span>"{{config_cache('session.domain')}}"</span></td>
 	</tr>
-
 	<tr>
 		<td><span class="badge badge-primary">TRUSTEDPROXY</span></td>
 		<td><strong>TRUST_PROXIES</strong></td>
 		<td><span>"{{config_cache('trustedproxy.proxies')}}"</span></td>
 	</tr>
+	<tr>
+		<td><span class="badge badge-primary">GLITCH</span></td>
+		<td><strong>GLITCH_LANDING_REALSTATCOUNT</strong></td>
+		<td><span>"{{config_cache('instance.glitch.real_stat_count')}}"</span></td>
+	</tr>	
       </tbody>
       </table>
   </div>

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 pkgs.mkShell {
   name = "pixelfed-nix-shell";
-  buildInputs = with pkgs; [ act docker php84 php84Packages.composer nodejs nodePackages.npm mkcert ddev hadolint dgoss ];
+  buildInputs = with pkgs; [ act docker php84 php84Packages.composer nodejs nodePackages.npm mkcert ddev hadolint dgoss gh ];
   runScript = "$SHELL";
   shellHook = ''
       mkcert -install


### PR DESCRIPTION
Fix the caching and loading of the newly added glitch env variable - wasnt loading properly. Added to the diagnostics too:

![image](https://github.com/user-attachments/assets/f463b229-3ee1-4f42-aed7-b6628db84a05)

Note: Beagle will now be FULLY disabled if the admin has it turned off in config (no auth callback)
