### PR TITLE
add RemoteIPTrustedProxy entry for private ipv6 cidr

### DIFF
--- a/docker/rootfs/apache/etc/apache2/conf-available/remoteip.conf
+++ b/docker/rootfs/apache/etc/apache2/conf-available/remoteip.conf
@@ -6,3 +6,4 @@ RemoteIPHeader X-Real-IP
 RemoteIPTrustedProxy 10.0.0.0/8
 RemoteIPTrustedProxy 172.16.0.0/12
 RemoteIPTrustedProxy 192.168.0.0/16
+RemoteIPTrustedProxy fc00::/7


### PR DESCRIPTION
Addresses issue where showing internal ip addresses for logins when proxy is using ipv6 (in my personal case when using CloudFlare Tunnels)